### PR TITLE
Add delegate to `createConnection` to further customize the `HubConnection`

### DIFF
--- a/src/createConnection.ts
+++ b/src/createConnection.ts
@@ -4,12 +4,19 @@ import {
   HubConnection,
 } from '@microsoft/signalr';
 
+export type HubConnectionBuilderDelegate = (
+  builder: HubConnectionBuilder
+) => HubConnectionBuilder;
+
 /**
  * Creates a signalr hub connection.
  * @param url - The URL of the signalr hub endpoint to connect to.
  * @param options - Options object to pass to connection builder.
+ * @param delegate - A delegate to further customize the HubConnection.
  */
 export const createConnection = (
   url: string,
-  options: IHttpConnectionOptions = {}
-): HubConnection => new HubConnectionBuilder().withUrl(url, options).build();
+  options: IHttpConnectionOptions = {},
+  delegate: HubConnectionBuilderDelegate = b => b
+): HubConnection =>
+  delegate(new HubConnectionBuilder()).withUrl(url, options).build();

--- a/test/useSignalr.test.ts
+++ b/test/useSignalr.test.ts
@@ -80,7 +80,11 @@ describe('useSignalr', () => {
       const { result } = renderHook(() => useSignalr('url1'));
 
       expect(createConnectionMock).toHaveBeenCalledTimes(1);
-      expect(createConnectionMock).toHaveBeenCalledWith('url1', undefined);
+      expect(createConnectionMock).toHaveBeenCalledWith(
+        'url1',
+        undefined,
+        undefined
+      );
       expect(result.current.on).toBeDefined();
       expect(result.current.on).toBeInstanceOf(Function);
       expect(result.current.send).toBeDefined();
@@ -94,7 +98,11 @@ describe('useSignalr', () => {
       const { result } = renderHook(() => useSignalr('url2', options));
 
       expect(createConnectionMock).toHaveBeenCalledTimes(1);
-      expect(createConnectionMock).toHaveBeenCalledWith('url2', options);
+      expect(createConnectionMock).toHaveBeenCalledWith(
+        'url2',
+        options,
+        undefined
+      );
       expect(result.current.on).toBeDefined();
       expect(result.current.on).toBeInstanceOf(Function);
       expect(result.current.send).toBeDefined();
@@ -121,7 +129,11 @@ describe('useSignalr', () => {
       renderHook(() => useSignalr('url2', options));
 
       expect(createConnectionMock).toHaveBeenCalledTimes(1);
-      expect(createConnectionMock).toHaveBeenCalledWith('url2', options);
+      expect(createConnectionMock).toHaveBeenCalledWith(
+        'url2',
+        options,
+        undefined
+      );
     });
 
     it('should stop the connection on unmount', () => {


### PR DESCRIPTION
Add delegate to `createConnection` to further customize the `HubConnection`.

Implements feature request #7 