### PR TITLE
Add support for endpoints with no argument

### DIFF
--- a/src/useSignalr.ts
+++ b/src/useSignalr.ts
@@ -21,7 +21,7 @@ interface UseSignalrHookResult {
    *
    * @typeparam TResponse - The expected response type.
    * @param methodName - The name of the server method to invoke.
-   * @param arg - The argument used to invoke the server method.
+   * @param arg - The argument used to invoke the server method. If no arg is passed or the value passed is undefined, nothing will be sent to the SignalR endpoint.
    *
    * @returns A promise that resolves what `HubConnection.invoke` would have resolved.
    *
@@ -44,7 +44,7 @@ interface UseSignalrHookResult {
    * Proxy to `HubConnection.send`
    *
    * @param methodName - The name of the server method to invoke.
-   * @param arg - The argument used to invoke the server method.
+   * @param arg - The argument used to invoke the server method. If no arg is passed or the value passed is undefined, nothing will be sent to the SignalR endpoint.
    *
    * @returns A promise that resolves when `HubConnection.send` would have resolved.
    *
@@ -125,7 +125,14 @@ export function useSignalr(
           // only take the current value of the observable
           take(1),
           // use the connection
-          switchMap(connection => connection.send(methodName, arg))
+          switchMap(connection => {
+            if (arg === undefined) {
+              // no argument provided
+              return connection.send(methodName);
+            } else {
+              return connection.send(methodName, arg);
+            }
+          })
         )
         .toPromise();
     },
@@ -139,7 +146,14 @@ export function useSignalr(
           // only take the current value of the observable
           take(1),
           // use the connection
-          switchMap(connection => connection.invoke<TResponse>(methodName, arg))
+          switchMap(connection => {
+            if (arg === undefined) {
+              // no argument provided
+              return connection.invoke<TResponse>(methodName);
+            } else {
+              return connection.invoke<TResponse>(methodName, arg);
+            }
+          })
         )
         .toPromise();
     },

--- a/test/useSignalr.test.ts
+++ b/test/useSignalr.test.ts
@@ -154,7 +154,18 @@ describe('useSignalr', () => {
   });
 
   describe('send', () => {
-    it('should call the HubConnection.send method', async () => {
+    it('should call the HubConnection.send method with no arg', async () => {
+      const options = {};
+
+      const { result } = renderHook(() => useSignalr('url2', options));
+
+      await act(() => result.current.send('test'));
+
+      expect(send).toHaveBeenCalledTimes(1);
+      expect(send).toHaveBeenCalledWith('test');
+    });
+
+    it('should call the HubConnection.send method with an arg', async () => {
       const options = {};
 
       const { result } = renderHook(() => useSignalr('url2', options));
@@ -167,7 +178,18 @@ describe('useSignalr', () => {
   });
 
   describe('invoke', () => {
-    it('should call the HubConnection.invoke method', async () => {
+    it('should call the HubConnection.invoke method with no arg', async () => {
+      const options = {};
+
+      const { result } = renderHook(() => useSignalr('url2', options));
+
+      await act(() => result.current.invoke<void>('test'));
+
+      expect(invoke).toHaveBeenCalledTimes(1);
+      expect(invoke).toHaveBeenCalledWith('test');
+    });
+
+    it('should call the HubConnection.invoke method with an arg', async () => {
       const options = {};
 
       const { result } = renderHook(() => useSignalr('url2', options));


### PR DESCRIPTION
Read the TSDoc for `SendFunction` and `InvokeFunction` carefully.

If an `undefined` argument is passed, the functions will act as if no argument was passed.